### PR TITLE
very rare bug fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
 ![Preview](.resources/ConstitutionalAmendments.png)
 
 ## Installation
-Download [ConstitutionalAmendments.ext](https://github.com/MeAndUnique/ConstitutionalAmendments/releases) and place in the extensions subfolder of the Fantasy Grounds data folder.
+Download [ConstitutionalAmendments.ext](https://github.com/rhagelstrom/ConstitutionalAmendments/releases) and place in the extensions subfolder of the Fantasy Grounds data folder.
 
 NOTE: Upon first loading, this extension will attempt to resolve each PC's current total hitpoints into individual rolls. If there is a discrepency detected a notification will be given upon opening the character sheet.
 

--- a/campaign/scripts/granthpheader.lua
+++ b/campaign/scripts/granthpheader.lua
@@ -1,5 +1,5 @@
--- 
--- Please see the license.txt file included with this distribution for 
+--
+-- Please see the license.txt file included with this distribution for
 -- attribution and copyright information.
 --
 

--- a/campaign/scripts/npc_main.lua
+++ b/campaign/scripts/npc_main.lua
@@ -1,5 +1,5 @@
--- 
--- Please see the license.txt file included with this distribution for 
+--
+-- Please see the license.txt file included with this distribution for
 -- attribution and copyright information.
 --
 

--- a/scripts/data_spell_ca.lua
+++ b/scripts/data_spell_ca.lua
@@ -1,5 +1,5 @@
--- 
--- Please see the license file included with this distribution for 
+--
+-- Please see the license file included with this distribution for
 -- attribution and copyright information.
 --
 

--- a/scripts/manager_string_ca.lua
+++ b/scripts/manager_string_ca.lua
@@ -1,5 +1,5 @@
--- 
--- Please see the license file included with this distribution for 
+--
+-- Please see the license file included with this distribution for
 -- attribution and copyright information.
 --
 
@@ -21,6 +21,9 @@ end
 
 function contains(set, item)
 	local result = containsOriginal(set, item);
+	if not item then
+		return result;
+	end
 	if not result and nCount > 0 then
 		for _,pattern in ipairs(set) do
 			if item:match('^' .. pattern .. '$') then

--- a/utility/scripts/dynamic_hp.lua
+++ b/utility/scripts/dynamic_hp.lua
@@ -1,5 +1,5 @@
--- 
--- Please see the license file included with this distribution for 
+--
+-- Please see the license file included with this distribution for
 -- attribution and copyright information.
 --
 
@@ -69,7 +69,7 @@ function onSourceTotalUpdate()
 		local nWounds = DB.getValue(sWounds, 0);
 		setValue(nTotal - nWounds);
 	end
-	
+
 	update();
 	bUpdating = false;
 end
@@ -114,9 +114,9 @@ function onValueChanged()
 	if sLink then
 		DB.setValue(sLink, "number", nWounds);
 	end
-	
+
 	DB.setValue(sWounds, "number", nWounds);
-	
+
 	update();
 	bUpdating = false;
 end
@@ -145,14 +145,14 @@ function setLink(dbnode, bLock)
 		DB.removeHandler(sLink, "onUpdate", onLinkUpdated);
 		sLink = nil;
 	end
-		
+
 	if dbnode then
 		sLink = dbnode.getNodeName();
 
 		if not nolinkwidget then
 			addBitmapWidget("field_linked").setPosition("bottomright", 0, -2);
 		end
-		
+
 		if bLock == true then
 			setReadOnly(true);
 		end


### PR DESCRIPTION
throwing error with misuse of effect syntax.  Shouldn't throw the error anymore.  Trimmed trailing spaces while i was at it.  Also linked rhagelstrom's github in the readme, as that is now where this extension is maintained.